### PR TITLE
remove required_base.css

### DIFF
--- a/theme/theme_base.css
+++ b/theme/theme_base.css
@@ -17,9 +17,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ========================================================================== 
 */
 
-/* This responsive framework is required for all styles. */
-{% include "hubspot/styles/responsive/required_base.css" %}
-
 /* These includes are optional, but helpful. */
 {% include "hubspot/styles/patches/recommended.css" %}
 


### PR DESCRIPTION
This file is now added automatically on all COS templates and is no longer needed as an include in your CSS file.