### PR TITLE
Add Color Variables to theme-variables.css #64: For Discussion

### DIFF
--- a/CrankShaft/code/hubl/theme-variables.css
+++ b/CrankShaft/code/hubl/theme-variables.css
@@ -14,6 +14,34 @@
 {% set accentColor2   = "#ccc" %}    /* {# Light Gray  |  Ex. "color: {{ accentColor2 }};" #} */
 {% set accentColor3   = "#ddd" %}    /* {# Lightest Gray  |  Ex. "color: {{ accentColor3 }};" #} */
 
+
+/* ======  @D.holdt addressing Add Color Variables to theme-variables.css ======*/
+/* How to use Color Variables 
+*
+*  1. Define your color variables semantically in {# what is the appropriate file for proper import? #} {# Ex. {% set brandBlue = #0366d6 %}
+*  2. Reference the desired color variable in the more generic variables.  {# ex. {% set primaryColor = brandBlue %}  #}
+*     2a. This method will make future edits to color sets more flexible (generic name used throughout CSS, 
+*         but semantically obvious at initial point of definition.
+*
+*   Helpful HubL Color Snippets  ( https://designers.hubspot.com/docs/hubl/hubl-supported-variables#variables-available-in-all-templates )
+*    1. {{ site_settings.primary_color }}
+*    2. {{ site_settings.secondary_color }}
+*    3. {{ site_settings.primary_accent_color }}
+*    4. {{ site_settings.secondary_accent_color }}
+*/
+
+{% set primaryColor    = yourVariableHere %}
+{% set secondaryColor  = yourVariableHere %}
+{% set tertiaryColor   = yourVariableHere %}
+{% set successColor    = yourVariableHere %}
+{% set dangerColor     = yourVariableHere %}
+{% set warningColor    = yourVariableHere %}
+{% set infoColor       = yourVariableHere %}
+
+{% set primaryColor_light   = color_variant(yourVariableHere, 15) %}  /*use this function to create a lighter or darker variant of a base color. Similar output to SASS*/
+{% set primaryColor_dark    = color_variant(yourVariableHere, -15) %}  /* 1 through 255 to lighten / -1 through -255 to darken   */
+
+
 /* Typography */
 {% set baseFontFamily    = "Arial, Sans-Serif" %}            /* {# Used on 'body' in 'Base'  |  Ex. "font-family: {{ baseFontFamily }};" #} */
 {% set baseFontSize      = "13px" %}                         /* {# Used on 'body' in 'Base'  |  Ex. "font-size: {{ baseFontSize }};" #} */


### PR DESCRIPTION
Here is an initial model with notes for a color variable pattern for Crankshaft. There is a color darkening/lightening variable native to hubL and that has been referenced, along with relevant snippets for simplicity. 

The idea is that the actual semantic color variables would be added by whomever is using crankshaft and then assign them to the more generic variables. These generic variables would then be what is used throughout the actual styles.